### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This script does **not** deploy Content Types. For Deploying Email Columns and C
 
     Install new PnP.PowerShell Cmdlets:
     ```
-    Install-Module -Name "PnP.PowerShell"
+    Install-Module -Name "PnP.PowerShell" -RequiredVersion 1.12.0
     ```
     Note that you will need to ensure you have uninstalled any previous 'Classic' or Legacy PnP Cmdlets prior to installing this. If you have installed the cmdlets previously using an MSI file these need to be uninstalled from Control Panel, but if you have installed the cmdlets previously using PowerShell Get you can uninstall them with this command (as Administrator):
 


### PR DESCRIPTION
Latest PnP.PowerShell 2.x.x drops support for PowerShell 5.1 and ISE, so need to specify version 1.12.0 to prevent users having to install PowerShell 7 and using Visual Studio Code to make any changes